### PR TITLE
Update pywin32 to 306

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setuptools.setup(
         "Operating System :: Microsoft :: Windows",
     ],
     python_requires='>=3.8',
-    install_requires=['pywin32==225', 'texttable']
+    install_requires=['pywin32==306', 'texttable']
 )


### PR DESCRIPTION
I tried to install the package with pip, but unfortunately the installation failed as the specified version of pywin32 was not available (any more).

```shell
PS ...\python-plantsim> pip3 install plantsim
Collecting plantsim
  Using cached plantsim-0.0.3-py3-none-any.whl (8.3 kB)
  Using cached plantsim-0.0.2-py3-none-any.whl (8.3 kB)
  Using cached plantsim-0.0.1-py3-none-any.whl (7.2 kB)
ERROR: Cannot install plantsim==0.0.1, plantsim==0.0.2 and plantsim==0.0.3 because these package versions have conflicting dependencies.

The conflict is caused by:
    plantsim 0.0.3 depends on pywin32==225
    plantsim 0.0.2 depends on pywin32==225
    plantsim 0.0.1 depends on pywin32==225

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
PS ...\python-plantsim>
```

I changed the setup.py as shown and was able to use the library as expected.

Tested on 12.04.2023, Python 3.10.11 on Win11.

Would be great if you could release a new version afterwards to (re)allow the installation via pip.