### PR TITLE
Add function to check if simulation is running

### DIFF
--- a/plantsim/plantsim.py
+++ b/plantsim/plantsim.py
@@ -77,6 +77,10 @@ class Plantsim:
 
         self.plantsim.StartSimulation(self.event_controller)
 
+    def is_simulation_running(self):
+
+        return self.plantsim.IsSimulationRunning()
+
     def get_object(self, object_name):
         # "Smart" getter that has some limited ability to decide which kind of object to return
 


### PR DESCRIPTION
For my simulation example, that I'll add in the next pr, #5, I needed a function to check if the simulation is still running. Even though the library so far didn't provide this information, I found a fork which added a function exactly for this; source is tmdt-buw/python-plantsim@33b88ea5b327b147c70238b0f9b8e61fa9f6deff